### PR TITLE
Update certbot_extra_formats: Add haproxy

### DIFF
--- a/certbot_extra_formats
+++ b/certbot_extra_formats
@@ -66,6 +66,9 @@ def write_cert(app, certroot="/etc/letsencrypt/live/", verbose=False):
         apps = {"ejabberd":['cat', ' ',
                             certs['privkey.pem'], ' ', certs['fullchain.pem'],
                             ' > ', certname],
+                "haproxy":['cat', ' ',
+                            certs['privkey.pem'], ' ', certs['fullchain.pem'],
+                            ' > ', certname],
                 "lighttpd":['cat', ' ',
                             certs['cert.pem'], ' ', certs['privkey.pem'],
                             ' > ', certname],
@@ -105,7 +108,7 @@ if __name__ == "__main__":
 
     parser = ArgumentParser(description="Write a \"Let's Ecrypt\" certificate compatible with a given application")
     parser.add_argument('--verbose', dest='verbose', action='store_true', default=False, help="extended output")
-    parser.add_argument('app', nargs='*', action='store', default=['lighttpd'], help="""application that request the certificate: ejabberd, lighttpd, tomcat7, httpd-dh (apache <= 2.4.7 with DH parameters)""")
+    parser.add_argument('app', nargs='*', action='store', default=['lighttpd'], help="""application that request the certificate: ejabberd, haproxy, lighttpd, tomcat7, httpd-dh (apache <= 2.4.7 with DH parameters)""")
     parser.add_argument('--certroot', dest='certroot', action='store', default="/etc/letsencrypt/live/", help="directory which contains the letsencrypt certificates")
     args = parser.parse_args()
 


### PR DESCRIPTION
Add haproxy

From haproxy docs:
```
... This file can be built by concatenating multiple PEM files into one (e.g. cat cert.pem key.pem > combined.pem). If your CA requires an intermediate certificate, this can also be concatenated into this file. ...
```

Links:
- https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#5.1-crt